### PR TITLE
Fix Android Tooltip position

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TouchableOpacity, Modal, View, StatusBar } from 'react-native';
+import { TouchableOpacity, Modal, View } from 'react-native';
 
 import { ViewPropTypes, withTheme } from '../config';
 import { ScreenWidth, ScreenHeight, isIOS } from '../helpers';
@@ -25,7 +25,8 @@ class Tooltip extends React.PureComponent {
     const { onClose } = this.props;
     this.getElementPosition();
     this.setState(prevState => {
-      if (prevState.isVisible && !isIOS) {
+      if (prevState.isVisible && !
+         ) {
         onClose && onClose();
       }
 
@@ -158,9 +159,7 @@ class Tooltip extends React.PureComponent {
         ) => {
           this.setState({
             xOffset: pageOffsetX,
-            yOffset: isIOS
-              ? pageOffsetY
-              : pageOffsetY - StatusBar.currentHeight,
+            yOffset: pageOffsetY,
             elementWidth: width,
             elementHeight: height,
           });


### PR DESCRIPTION
Issue is reproduced for example on: Android 9, RN 0.59.8, RNE 1.1.0

Displayed element wrapped in Tooltip is shown shifted up from the original element. See image below

Current Android behavior: 
![65609483_354296048567220_5352678562589573120_n](https://user-images.githubusercontent.com/2223591/60211327-10a3dc00-985f-11e9-821c-f57e88d3970c.png)
After fix:
![65317028_443290659784941_2625493953058701312_n](https://user-images.githubusercontent.com/2223591/60211328-10a3dc00-985f-11e9-9372-0c4718e79e71.png)
