### PR TITLE
Fix Android Tooltip position

### DIFF
--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TouchableOpacity, Modal, View, StatusBar } from 'react-native';
+import { TouchableOpacity, Modal, View } from 'react-native';
 
 import { ViewPropTypes, withTheme } from '../config';
 import { ScreenWidth, ScreenHeight, isIOS } from '../helpers';
@@ -158,9 +158,7 @@ class Tooltip extends React.PureComponent {
         ) => {
           this.setState({
             xOffset: pageOffsetX,
-            yOffset: isIOS
-              ? pageOffsetY
-              : pageOffsetY - StatusBar.currentHeight,
+            yOffset: pageOffsetY,
             elementWidth: width,
             elementHeight: height,
           });


### PR DESCRIPTION
Issue is reproduced for example on: Android 9, RN 0.59.8, RNE 1.1.0

Displayed element wrapped in Tooltip is shown shifted up from the original element. See image below

### Current behavior:
![65609483_354296048567220_5352678562589573120_n](https://user-images.githubusercontent.com/2223591/60212828-734aa700-9862-11e9-81b4-6e60e3492cd9.png)

### After fix:
![65317028_443290659784941_2625493953058701312_n](https://user-images.githubusercontent.com/2223591/60212827-734aa700-9862-11e9-998b-5a06453ff206.png)


